### PR TITLE
Signing Secret & Cancellation

### DIFF
--- a/config/initializers/stripe_event.rb
+++ b/config/initializers/stripe_event.rb
@@ -1,3 +1,6 @@
+# SIGNING REQUIRED AS OF STRIPE 2.0
+StripeEvent.signing_secret = ENV['STRIPE_SIGNING_SECRET'] 
+
 StripeEvent.configure do |events|
   events.subscribe 'charge.failed' do |event|
     stripe_id = event.data.object['customer']


### PR DESCRIPTION
This is not tested yet, but wanted to walk you through my thinking before I mock up some webhooks. Basically this is taking the existing code and creating a method to respond to it. Previously the `try(:cancel)` would have returned nil.

```ruby
events.subscribe 'customer.subscription.deleted' do |event|
  stripe_id = event.data.object['customer']
  subscription = ::Subscription.find_by_stripe_id(stripe_id)
  subscription.subscription_owner.try(:cancel)
end
```

My cancel method just uses the method you used to have in the Rake task and moves it into the Subscription object. Should be sufficient, but I want to make sure we're handling things the right way. 