### PR TITLE
Invoicing Support

### DIFF
--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -318,7 +318,7 @@ module Koudoku::Subscription
   end
 
   # stripe web-hook callbacks.
-  def payment_succeeded(amount, invoice = {})
+  def payment_succeeded(amount, invoice_id)
   end
 
   def charge_failed

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -318,7 +318,7 @@ module Koudoku::Subscription
   end
 
   # stripe web-hook callbacks.
-  def payment_succeeded(amount)
+  def payment_succeeded(amount, invoice = {})
   end
 
   def charge_failed

--- a/config/initializers/stripe_event.rb
+++ b/config/initializers/stripe_event.rb
@@ -4,17 +4,16 @@ StripeEvent.signing_secret = ENV['STRIPE_SIGNING_SECRET']
 StripeEvent.configure do |events|
   events.subscribe 'charge.failed' do |event|
     stripe_id = event.data.object['customer']
-      
     subscription = ::Subscription.find_by_stripe_id(stripe_id)
     subscription.charge_failed
   end
   
   events.subscribe 'invoice.payment_succeeded' do |event|
     invoice = event.data.object
-    stripe_id = invoice['customer']
-    amount = invoice['total'].to_f / 100.0
+    stripe_id = invoice.customer
+    amount = invoice.total.to_f / 100.0
     subscription = ::Subscription.find_by_stripe_id(stripe_id)
-    subscription.payment_succeeded(amount, invoice)
+    subscription.payment_succeeded(amount, invoice.id)
   end
   
   events.subscribe 'charge.dispute.created' do |event|

--- a/config/initializers/stripe_event.rb
+++ b/config/initializers/stripe_event.rb
@@ -10,10 +10,11 @@ StripeEvent.configure do |events|
   end
   
   events.subscribe 'invoice.payment_succeeded' do |event|
-    stripe_id = event.data.object['customer']
-    amount = event.data.object['total'].to_f / 100.0
+    invoice = event.data.object
+    stripe_id = invoice['customer']
+    amount = invoice['total'].to_f / 100.0
     subscription = ::Subscription.find_by_stripe_id(stripe_id)
-    subscription.payment_succeeded(amount)
+    subscription.payment_succeeded(amount, invoice)
   end
   
   events.subscribe 'charge.dispute.created' do |event|

--- a/lib/koudoku/version.rb
+++ b/lib/koudoku/version.rb
@@ -1,3 +1,3 @@
 module Koudoku
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end

--- a/lib/koudoku/version.rb
+++ b/lib/koudoku/version.rb
@@ -1,3 +1,3 @@
 module Koudoku
-  VERSION = "1.3.3"
+  VERSION = "1.3.31"
 end


### PR DESCRIPTION
This takes the Stripe Webhook Event and Invoice and passes the ID to the Subscription object to process. Only on successful payment. The rest is managed in the main app. **Need to force upgrade on main app Gemfile in order to reflect changes** 